### PR TITLE
Fix link to create diaries

### DIFF
--- a/frontend/mit-app/src/app/diaries/page.tsx
+++ b/frontend/mit-app/src/app/diaries/page.tsx
@@ -51,7 +51,7 @@ const DiaryPage = () => {
         <h1 className="text-2xl font-bold">日報管理</h1>
         <div className="flex space-x-4">
           <Link
-            href="/wikis/new"
+            href="/diaries/new"
             className="bg-blue-500 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-blue-600 active:scale-95 transition-transform"
           >
             日報登録


### PR DESCRIPTION
## Summary
- fix link on diaries page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684452b22be0833283f2ce7b7ad21361