### PR TITLE
Add Dify chatbot with toggle button

### DIFF
--- a/frontend/mit-app/src/app/components/DifyChatbot.tsx
+++ b/frontend/mit-app/src/app/components/DifyChatbot.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import Script from 'next/script';
+
+const DifyChatbot = () => {
+  const [visible, setVisible] = useState(true);
+
+  const toggleChatbot = () => {
+    const bubbleButton = document.getElementById('dify-chatbot-bubble-button');
+    const bubbleWindow = document.getElementById('dify-chatbot-bubble-window');
+    if (bubbleButton) bubbleButton.style.display = visible ? 'none' : 'block';
+    if (bubbleWindow) bubbleWindow.style.display = 'none';
+    setVisible(!visible);
+  };
+
+  return (
+    <>
+      <button
+        onClick={toggleChatbot}
+        className="fixed bottom-24 right-4 z-50 bg-blue-500 text-white px-4 py-2 rounded shadow"
+      >
+        {visible ? 'チャット非表示' : 'チャット表示'}
+      </button>
+      <Script id="dify-chatbot-config" strategy="afterInteractive">
+        {`window.difyChatbotConfig = {
+          token: 'Sz6ao2xKv8A0xVph',
+          baseUrl: 'http://192.168.0.33',
+          systemVariables: {}
+        };`}
+      </Script>
+      <Script
+        src="http://192.168.0.33/embed.min.js"
+        id="Sz6ao2xKv8A0xVph"
+        strategy="afterInteractive"
+      />
+    </>
+  );
+};
+
+export default DifyChatbot;

--- a/frontend/mit-app/src/app/globals.css
+++ b/frontend/mit-app/src/app/globals.css
@@ -37,3 +37,12 @@
 .markdown hr {
     @apply my-5
 }
+
+#dify-chatbot-bubble-button {
+    background-color: #1C64F2 !important;
+}
+
+#dify-chatbot-bubble-window {
+    width: 24rem !important;
+    height: 40rem !important;
+}

--- a/frontend/mit-app/src/app/layout.tsx
+++ b/frontend/mit-app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import React from "react";
 import Link from 'next/link';
+import DifyChatbot from './components/DifyChatbot';
 
 const RootLayout = ({
     children,
@@ -29,6 +30,8 @@ const RootLayout = ({
                 <footer className="bg-gray-700 text-white py-4 px-6 fixed bottom-0 w-full z-10">
                     <p className="text-center text-sm">&copy; 2024 - 2025 Local Environment Personal App</p>
                 </footer>
+
+                <DifyChatbot />
             </body>
         </html>
     );


### PR DESCRIPTION
## Summary
- embed Dify chat bot across the site
- allow hiding/showing the chat widget with a toggle button
- style chat bubble via global CSS

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844568385b48332aeac5e6f62655eac